### PR TITLE
Fix button-breakage from #56

### DIFF
--- a/contents/css/_links.css
+++ b/contents/css/_links.css
@@ -10,7 +10,7 @@ a {
 }
 
 /* Default links on main content area */
-.main-wrapper a,
+.md-content a,
 .link--underline {
   border-bottom: 4px solid var(--returnrose);
 

--- a/templates/pages/call-for-speakers.html.njk
+++ b/templates/pages/call-for-speakers.html.njk
@@ -5,7 +5,7 @@
 {% block content %}
 
   <section class="grid">
-    <div class="grid-item-center">
+    <div class="grid-item-center md-content">
       {{ contents.copy.cfs['open-until.md'].html }}
     </div>
   </section>
@@ -19,7 +19,7 @@
   </section>
 
   <section class="grid">
-    <div class="grid-item-center">
+    <div class="grid-item-center md-content">
       {{ contents.copy.cfs['topics.md'].html }}
     </div>
   </section>
@@ -32,19 +32,19 @@
   </section>
 
   <section class="grid">
-    <div class="grid-item-center">
+    <div class="grid-item-center md-content">
       {{ contents.copy.cfs['we-can-help.md'].html }}
     </div>
   </section>
 
   <section class="grid">
-    <div class="grid-item-center">
+    <div class="grid-item-center md-content">
       {{ contents.copy.cfs['perks.md'].html }}
     </div>
   </section>
 
   <section class="grid">
-    <div class="grid-item-center">
+    <div class="grid-item-center md-content">
       {{ contents.copy.cfs['selection-process.md'].html }}
     </div>
   </section>
@@ -58,19 +58,19 @@
   </section>
 
   <section class="grid">
-    <div class="grid-item-center">
+    <div class="grid-item-center md-content">
       {{ contents.copy.cfs['guidelines.md'].html }}
     </div>
   </section>
 
   <section class="grid">
-    <div class="grid-item-center">
+    <div class="grid-item-center md-content">
       {{ contents.copy.cfs['video-recordings.md'].html }}
     </div>
   </section>
 
   <section class="grid">
-    <div class="grid-item-center">
+    <div class="grid-item-center md-content">
       {{ contents.copy.cfs['coc.md'].html }}
     </div>
   </section>

--- a/templates/pages/code-of-conduct.html.njk
+++ b/templates/pages/code-of-conduct.html.njk
@@ -3,7 +3,7 @@
 {% block content %}
 
   <section class="grid">
-    <div class="grid-item-center">
+    <div class="grid-item-center md-content">
       {{ contents.copy.coc['code-of-conduct.md'].html }}
     </div>
   </section>

--- a/templates/pages/imprint.html.njk
+++ b/templates/pages/imprint.html.njk
@@ -3,7 +3,7 @@
 {% block content %}
 
   <section class="grid">
-    <div class="grid-item-center">
+    <div class="grid-item-center md-content">
       {{ contents.copy.imprint['imprint.md'].html }}
     </div>
   </section>

--- a/templates/pages/scholarships.html.njk
+++ b/templates/pages/scholarships.html.njk
@@ -3,7 +3,7 @@
 {% block content %}
 
   <section class="grid">
-    <div class="grid-item-center">
+    <div class="grid-item-center md-content">
       {{ contents.copy.scholarships['scholarships.md'].html }}
     </div>
   </section>

--- a/templates/pages/sponsors.html.njk
+++ b/templates/pages/sponsors.html.njk
@@ -3,7 +3,7 @@
 {% block content %}
 
   <section class="grid">
-    <div class="grid-item-center">
+    <div class="grid-item-center md-content">
       {{ contents.copy.sponsors['sponsors.md'].html }}
     </div>
   </section>

--- a/templates/pages/time.html.njk
+++ b/templates/pages/time.html.njk
@@ -3,7 +3,7 @@
 {% block content %}
 
   <section class="grid">
-    <div class="grid-item-center">
+    <div class="grid-item-center md-content">
       {{ contents.copy.time['time.md'].html }}
     </div>
   </section>


### PR DESCRIPTION
Due to a oversight on my part in #56, a too broad selector (`.main-wrapper a`) for the underlined links leads to problems with the `.btn` buttons, which can be `.main-wrapper a` as well.

Understanding that the `.main-wrapper a` selector was used to also affect all links coming from markdown content, I added a new class `.md-content` on all elements containing content from markdown so we can target that instead.

An alternative option would be to only target links with no further class (`.main-wrapper a:not([class])`).

wdyt? 