### PR TITLE
Add the news section

### DIFF
--- a/contents/news.json
+++ b/contents/news.json
@@ -1,0 +1,6 @@
+{
+  "pageId": "news",
+  "template": "pages/news.html.njk",
+  "filename": ":file/index.html",
+  "title": "News"
+}

--- a/contents/news/news-template.md
+++ b/contents/news/news-template.md
@@ -1,0 +1,11 @@
+----
+template: pages/news-item.html.njk
+filename: :file/index.html
+
+draft: true
+
+title: News Template
+date: 2017-12-22
+----
+
+Content goes here

--- a/templates/pages/news-item.html.njk
+++ b/templates/pages/news-item.html.njk
@@ -3,10 +3,10 @@
 {% block content %}
   <h1>{{ speaker.fullName }}</h1>
 
-  <section class="grid">
+  <article class="grid">
     <div class="grid-item-center md-content">
       {{ page.html }}
     </div>
-  </section>
+  </article>
 
 {% endblock %}

--- a/templates/pages/news-item.html.njk
+++ b/templates/pages/news-item.html.njk
@@ -1,0 +1,12 @@
+{% extends "../layouts/default.html.njk" %}
+
+{% block content %}
+  <h1>{{ speaker.fullName }}</h1>
+
+  <section class="grid">
+    <div class="grid-item-center md-content">
+      {{ page.html }}
+    </div>
+  </section>
+
+{% endblock %}

--- a/templates/pages/news.html.njk
+++ b/templates/pages/news.html.njk
@@ -1,0 +1,19 @@
+{% extends "../layouts/default.html.njk" %}
+
+{% set newsList = contents.news._.pages %}
+
+{% block content %}
+
+  <section class="grid">
+    <div class="grid-item-center md-content">
+      {% for news in newsList %}
+        {% if news.metadata.draft !== true %}
+          <h2>{{ news.title }}</h2>
+          {{ news.html | truncate('150') }}
+          <a href="{{ news.url }}">Read more</a>
+        {% endif %}
+      {% endfor %}
+    </div>
+  </section>
+
+{% endblock %}

--- a/templates/pages/news.html.njk
+++ b/templates/pages/news.html.njk
@@ -8,9 +8,11 @@
     <div class="grid-item-center md-content">
       {% for news in newsList %}
         {% if news.metadata.draft !== true %}
-          <h2>{{ news.title }}</h2>
-          {{ news.html | truncate('150') }}
-          <a href="{{ news.url }}">Read more</a>
+          <article>
+            <h2>{{ news.title }}</h2>
+            {{ news.html | truncate('150') }}
+            <a href="{{ news.url }}">Read more</a>
+          </article>
         {% endif %}
       {% endfor %}
     </div>


### PR DESCRIPTION
My first attempt to bring the News section to JSConf EU.

Here’s the structure we should follow:
1. We add new News item as a Markdown file under `contents/news` (see `news-template.md` as a reference).
    1. You can use a draft by setting the ”draft” metadata in the news item’s formatter. All of the News items with this metadata would not be shown on the News list (however they would still be accessible via the news item details link)
1. List of news can be accessed at `/news/`.
1. A specific news item can be accessed at `/news/news-title/`

You can see a preview here: https://user-images.githubusercontent.com/11782/34304446-1a01e274-e73a-11e7-871b-d429d972f588.png