### PR TITLE
Add announcement post for Mercedes-Benz.io sponsorship

### DIFF
--- a/templates/pages/index.html.njk
+++ b/templates/pages/index.html.njk
@@ -62,6 +62,21 @@
       {{ svgIcon('form-home-coc', viewBox='0 0 658 725', svgClass="svg-scale") }}
     </div>
     <h2 class="heading--massive grid-head mt0">
+      Mercedes-Benz.io supports Scholarship Program
+    </h2>
+    <div class="grid-content">
+      <p>
+        We are happy to announce that Mercedes-Benz.io will support the JSConf EU and CSSconf EU Scholarship Program by donating funds for 30 additional scholarships per each event.
+        <br><br>
+        This will enable up to 60 people from underrepresented groups to attend two of the largest and most renowned European developer conferences, and experience this unique opportunity to learn, grow, and connect with the community. This is a big step towards our goal of running our yet largest and most impactful scholarship program, and we thank Mercedes-Benz.io for their generous support.
+        <br><br>
+        <a href="http://Mercedes-Benz.io" class="link--underline">Mercedes-Benz.io</a> is Daimler’s digital delivery hub working on products for the Sales and Marketing efforts of Mercedes-Benz and has offices in Berlin, Lisbon, and Stuttgart.
+      </p>
+    </div>
+  </section>
+
+  <section class="tc tl-l grid grid-5-4 mb6 mb7-l">
+    <h2 class="heading--massive grid-head mt0">
       People First. Always.
     </h2>
     <div class="grid-content">


### PR DESCRIPTION
Added the copy (as agreed with Mercedes-Benz.io, this needs to go live before end of year).

The layout is not ideal yet for longer copy like this. This will be addressed in https://github.com/jsconf/2018.jsconf.eu/issues/47

/cc @lukaszklis @silkine 