### PR TITLE
Move MB article to be proper news article and link news on homepage and main nav.

### DIFF
--- a/contents/news/mercedes-benz-supports-scholarship-program.md
+++ b/contents/news/mercedes-benz-supports-scholarship-program.md
@@ -1,0 +1,13 @@
+----
+template: pages/news-item.html.njk
+filename: :file/index.html
+
+title: Mercedes-Benz.io supports Scholarship Program
+date: 2017-12-22
+----
+
+We are happy to announce that [Mercedes-Benz.io](https://mercedes-benz.io/) will support the JSConf EU and CSSconf EU Scholarship Program by donating funds for 30 additional scholarships per each event.
+
+This will enable up to 60 people from underrepresented groups to attend two of the largest and most renowned European developer conferences, and experience this unique opportunity to learn, grow, and connect with the community. This is a big step towards our goal of running our yet largest and most impactful scholarship program, and we thank Mercedes-Benz.io for their generous support.
+
+[Mercedes-Benz.io](https://mercedes-benz.io/) is Daimler’s digital delivery hub working on products for the Sales and Marketing efforts of Mercedes-Benz and has offices in Berlin, Lisbon, and Stuttgart.

--- a/templates/pages/index.html.njk
+++ b/templates/pages/index.html.njk
@@ -57,20 +57,21 @@
     </div>
   </section>
 
+  {% set latest = contents.news._.pages | first %}
   <section class="tc tl-l grid grid-4-5 mb6 mb7-l">
     <div class="grid-form-home-coc">
       {{ svgIcon('form-home-coc', viewBox='0 0 658 725', svgClass="svg-scale") }}
     </div>
     <h2 class="heading--massive grid-head mt0">
-      Mercedes-Benz.io supports Scholarship Program
+      News
     </h2>
     <div class="grid-content">
+      <h3 class="heading--spaced mt0">
+        {{ latest.title }}
+      </h3>
       <p>
-        We are happy to announce that Mercedes-Benz.io will support the JSConf EU and CSSconf EU Scholarship Program by donating funds for 30 additional scholarships per each event.
-        <br><br>
-        This will enable up to 60 people from underrepresented groups to attend two of the largest and most renowned European developer conferences, and experience this unique opportunity to learn, grow, and connect with the community. This is a big step towards our goal of running our yet largest and most impactful scholarship program, and we thank Mercedes-Benz.io for their generous support.
-        <br><br>
-        <a href="http://Mercedes-Benz.io" class="link--underline">Mercedes-Benz.io</a> is Daimler’s digital delivery hub working on products for the Sales and Marketing efforts of Mercedes-Benz and has offices in Berlin, Lisbon, and Stuttgart.
+        {{ latest.html | truncate('300') }}
+        <a href="{{ latest.url }}">Read more</a>
       </p>
     </div>
   </section>

--- a/templates/partials/topbar.html.njk
+++ b/templates/partials/topbar.html.njk
@@ -12,7 +12,7 @@
     <nav id="topbar-nav" class="topbar-nav items-center">
       <a href="{{ contents['call-for-speakers.json'].url }}" class="link--promiselinen link--nav">Call for Speakers</a>
       <a href="{{ contents['scholarships.json'].url }}" class="link--promiselinen link--nav">Scholarships</a>
-      <a href="{{ contents['code-of-conduct.json'].url }}" class="link--promiselinen link--nav">Code of Conduct</a>
+      <a href="{{ contents['news.json'].url }}" class="link--promiselinen link--nav">News</a>
       <a href="{{ contents['sponsors.json'].url }}" class="link--promiselinen link--nav">Sponsors</a>
       <div class="social-links flex items-center">
         <a href="https://www.youtube.com/jsconfeu" class="link--promiselinen link--nav-icon" title="YouTube">


### PR DESCRIPTION
Credits to @lukaszklis for introducing the news section in #62 and to @kriesse for providing the content in #64.

This PR moves the MB content into a proper news article and then:

- actually links the news section in the main navigation
- and replaces the MB content on the homepage with automatically a generated snippet of the latest news post.

Does not fix the problem that this doesn't look particularly good yet as #64 mentions :)