### PR TITLE
Convert URLs to static assets into immutable URLs

### DIFF
--- a/contents/css/_layout.css
+++ b/contents/css/_layout.css
@@ -185,7 +185,7 @@
 
 .page-cfs {
   @media (--medium) {
-    background-image: url('../svg/form-cfs-01.svg');
+    background-image: url('contents:svg/form-cfs-01.svg');
     background-size: 125%;
     background-position: -13rem -2rem;
   }

--- a/contents/css/_topbar.css
+++ b/contents/css/_topbar.css
@@ -102,7 +102,7 @@
     position: absolute;
     bottom: calc(-1rem + 1px);
     display: block;
-    background: transparent repeat-x url(../svg/zigzag-border.svg);
+    background: transparent repeat-x url(contents:svg/zigzag-border.svg);
     background-size: cover;
   }
 }

--- a/contents/css/_typography.css
+++ b/contents/css/_typography.css
@@ -9,7 +9,7 @@ body {
   letter-spacing: 0.025em;
   color: var(--evalblack);
   background-color: var(--promiselinen);
-  background-image: url('../images/pattern.svg');
+  background-image: url('contents:images/pattern.svg');
   background-position: center;
   background-repeat: no-repeat;
   background-attachment: fixed;

--- a/package-lock.json
+++ b/package-lock.json
@@ -684,6 +684,11 @@
         "css-tree": "1.0.0-alpha25"
       }
     },
+    "cuint": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
+      "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs="
+    },
     "cycle": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
@@ -7737,6 +7742,18 @@
         }
       }
     },
+    "postcss-url": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-url/-/postcss-url-7.3.0.tgz",
+      "integrity": "sha512-VBP6uf6iL3AZra23nkPkOEkS/5azj1xf/toRrjfkolfFEgg9Gyzg9UhJZeIsz12EGKZTNVeGbPa2XtaZm/iZvg==",
+      "requires": {
+        "mime": "1.4.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "postcss": "6.0.14",
+        "xxhashjs": "0.2.1"
+      }
+    },
     "postcss-value-parser": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
@@ -8438,6 +8455,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xxhashjs": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/xxhashjs/-/xxhashjs-0.2.1.tgz",
+      "integrity": "sha1-m76b6JYUKXbfo0wGGy0GjEPTDeA=",
+      "requires": {
+        "cuint": "0.2.2"
+      }
     },
     "y18n": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "postcss": "^6.0.16",
     "postcss-cssnext": "^3.0.2",
     "postcss-import": "^11.0.0",
+    "postcss-url": "^7.3.0",
     "prettier": "^1.10.2",
     "svgo": "^1.0.3",
     "svgstore": "^2.0.2",

--- a/plugins/postcss.js
+++ b/plugins/postcss.js
@@ -27,8 +27,17 @@ module.exports = (wintersmith, callback) => {
       this._text = _text;
     }
 
+    // Transform URLs into the form:
+    // /immutable/$hashOfAllCSSFiles/filename
     getFilename() {
-      return this._filepath.relative;
+      const hash = require('crypto').createHash('sha1');
+      const fs = require('fs');
+      const path = 'contents/css/';
+      const files = fs.readdirSync(path);
+      files.forEach(name => {
+        hash.update(fs.readFileSync(path + name), 'utf8');
+      });
+      return 'immutable/' + hash.digest('hex') + '/' + this._filepath.relative;
     }
 
     getView() {
@@ -40,8 +49,28 @@ module.exports = (wintersmith, callback) => {
           options.plugins = options.plugins || [];
 
           wintersmith.logger.verbose('loading postcss-plugins');
+          // Allows to refer to windersmith resource URLs as
+          // url('contents:directory/filename')
+          options.plugins.push({
+            "path": "postcss-url",
+            "params": {
+              url: asset => {
+                if (asset.url.startsWith('contents:')) {
+                  const path = asset.url.split(':')[1];
+                  const parts = path.split('/');
+                  if (parts.length != 2) {
+                    throw new Error('Expected format contents:directory/filename');
+                  }
+                  return contents[parts[0]][parts[1]].url;
+                }
+                if (!asset.url.startsWith('data:')) {
+                  throw new Error('Use contents: or data: URLs: ' + asset.url);
+                }
+                return asset.url;
+              }
+            }
+          });
           const plugins = options.plugins.map(loadPlugin);
-
           wintersmith.logger.verbose('compile css');
           postcss(plugins)
             .process(this._text, options)

--- a/templates/layouts/default.html.njk
+++ b/templates/layouts/default.html.njk
@@ -9,7 +9,7 @@
     {% endif %}
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel=stylesheet href="{{ contents.css["main.css"].url }}">
-    <link rel=preload href="/images/pattern.svg" as=image>
+    <link rel=preload href="{{ contents.images["pattern.svg"].url }}" as=image>
     <link rel=preload href="https://use.typekit.net/af/6c9c65/00000000000000003b9adf44/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3"
         as=font crossorigin>
     <link rel=preload href="https://use.typekit.net/af/16a56f/00000000000000003b9adf46/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3"


### PR DESCRIPTION
I configured cloudflare to assign a 1 year cache time to every resource starting with `immutable/`.

Sorry for the nasty implementation. It would be much nicer if wintersmith has a pipeline of plugins instead of assigning each resource to exactly one of them.