### PR TITLE
Emit all data for speaker pages.

### DIFF
--- a/scripts/spreadsheet-import/index.js
+++ b/scripts/spreadsheet-import/index.js
@@ -113,6 +113,7 @@ const filterUnpublished =
         );
 
         const {content, ...frontmatterData} = record;
+        templateGlobals.title = `${frontmatterData.firstname} ${frontmatterData.lastname}: ${frontmatterData.talkTitle}`
         const frontmatter = yaml.safeDump({
           ...templateGlobals,
           [dataFieldName]: frontmatterData

--- a/templates/pages/speaker.html.njk
+++ b/templates/pages/speaker.html.njk
@@ -3,15 +3,5 @@
 {% set speaker = page.metadata.speaker %}
 
 {% block content %}
-    <h1>{{ speaker.fullName }}</h1>
-
-    <div class="md-content">
-        {{ page.html }}
-    </div>
-
-    <ul>
-        {% for link in speaker.links %}
-            <li><a href="{{ link.url }}">{{ link.text }}</a></li>
-        {% endfor %}
-    </ul>
+  {% include "../partials/talk.html.njk" %}
 {% endblock %}

--- a/templates/pages/speakers.html.njk
+++ b/templates/pages/speakers.html.njk
@@ -7,7 +7,7 @@
         {% for page in speakerPages %}
             {% set speaker = page.metadata.speaker %}
 
-            <li><a href="{{ page.url }}">{{ speaker.fullName }}</a></li>
+            {% include "../partials/talk.html.njk" %}
         {% endfor %}
     </ul>
 {% endblock %}

--- a/templates/partials/talk.html.njk
+++ b/templates/partials/talk.html.njk
@@ -1,0 +1,18 @@
+<h1><a href="{{ page.url }}">{{ speaker.firstname }} {{ speaker.lastname }}: {{ speaker.talkTitle }}</a></h1>
+
+<div class="md-content">
+    <img src="{{ speaker.potraitImageUrl }}" align=right>
+    {{ page.html }}
+</div>
+
+<ul>
+    {% if speaker.links.twitter %}
+      <li class="twitter"><a href="{{ speaker.links.twitter }}">Twitter: {{ speaker.twitterHandle }}</a></li>
+    {% endif %}
+    {% if speaker.links.github %}
+      <li class="github"><a href="{{ speaker.links.github }}">GitHub: {{ speaker.githubHandle }}</a></li>
+    {% endif %}
+    {% if speaker.links.homepage %}
+      <li class="github"><a href="{{ speaker.links.homepage }}">Website</a></li>
+    {% endif %}
+</ul>


### PR DESCRIPTION
- Adopts templates to actual spreadsheet.
- Makes overview page have all content.
- Changes the import script to emit the title as document meta data.