### PR TITLE
fix: async race-condition

### DIFF
--- a/contents/speakers/ashi-krishnan-deep-learning-in-js.md
+++ b/contents/speakers/ashi-krishnan-deep-learning-in-js.md
@@ -20,6 +20,7 @@ speaker:
     homepage: 'http://ashi.io'
   country: United States
   city: 'New York, NY'
+  name: Ashi Krishnan
   image:
     filename: ashi-krishnan.jpg
     width: 440

--- a/contents/speakers/emil-bay-hand-crafting-webassembly.md
+++ b/contents/speakers/emil-bay-hand-crafting-webassembly.md
@@ -20,6 +20,7 @@ speaker:
     homepage: 'http://bayes.dk'
   country: Denmark
   city: Denmark
+  name: Emil Bay
   image:
     filename: emil-bay.jpg
     width: 440

--- a/contents/speakers/shelley-vohr-asynchrony-under-the-hood.md
+++ b/contents/speakers/shelley-vohr-asynchrony-under-the-hood.md
@@ -20,6 +20,7 @@ speaker:
     homepage: 'http://codebyte.re'
   country: USA
   city: 'San Francisco, CA'
+  name: Shelley Vohr
   image:
     filename: shelley-vohr.jpg
     width: 440

--- a/scripts/spreadsheet-import/index.js
+++ b/scripts/spreadsheet-import/index.js
@@ -22,13 +22,6 @@ const sheetParams = {
     },
     dataFieldName: 'speaker',
     contentPath: 'speakers'
-  },
-  talks: {
-    templateGlobals: {
-      template: 'pages/talk.html.njk'
-    },
-    dataFieldName: 'talk',
-    contentPath: 'talks'
   }
 };
 
@@ -116,21 +109,21 @@ const filterUnpublished =
           `${record.id}${record.published ? '' : '-PREVIEW'}.md`
         );
 
-        const {content, ...frontmatterData} = record;
-        templateGlobals.title =
-          `${frontmatterData.firstname} ${frontmatterData.lastname}:` +
-          ` ${frontmatterData.talkTitle}`;
+        const {content, ...speakerData} = record;
 
-        frontmatterData.image = getLocalImage(frontmatterData);
-        if (!frontmatterData.image) {
-          frontmatterData.image = await downloadImage(frontmatterData);
+        speakerData.name = speakerData.firstname + ' ' + speakerData.lastname;
+
+        speakerData.image = getLocalImage(speakerData);
+        if (!speakerData.image) {
+          speakerData.image = await downloadImage(speakerData);
         }
 
-        delete frontmatterData.potraitImageUrl;
+        delete speakerData.potraitImageUrl;
 
         const frontmatter = yaml.safeDump({
           ...templateGlobals,
-          [dataFieldName]: frontmatterData
+          title: `${speakerData.name}: ${speakerData.talkTitle}`,
+          [dataFieldName]: speakerData
         });
 
         console.log(


### PR DESCRIPTION
writing to templateGlobals in an async context lets the last value written 
win, hence the problem with identical titles on all pages yesterday. 
Didn't happen for me as using local files keeps everything running in sync.

Also adds a new frontmatter-variable `name`, which might make sense at some point.