### PR TITLE
Switch to external SVGs

### DIFF
--- a/templates/_macros.njk
+++ b/templates/_macros.njk
@@ -1,8 +1,11 @@
-{% macro svgIcon(id, svgClass, viewBox = '0 0 16 16', title = '') %}
-  <svg class="svg svg-{{ id }} {{ svgClass }}" viewbox="{{ viewBox }}">
+{% macro svgIcon(contents, id, svgClass, width = 16, height = 16, title = '') %}
+  <svg viewbox="0 0 {{ width }} {{ height }}" class="svg svg-{{ id }} {{ svgClass }}">
     {% if title %}
       <title id='title-{{ id }}'>{{ title }}</title>
     {% endif %}
-    <use xlink:href="#{{ id }}"></use>
+    <image xlink:href="{{ contents.svg[id + '.svg'].url }}"
+        height="{{ height }}px"
+        width="{{ width }}px"/>
   </svg>
+  <link rel=preload as=image href="{{ contents.svg[id + '.svg'].url }}">
 {% endmacro %}

--- a/templates/layouts/default.html.njk
+++ b/templates/layouts/default.html.njk
@@ -5,25 +5,8 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <title>{% if page.title %}{{ page.title }}{% endif %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <script>
-      fetch('{{ contents.svg['sprite.svg'].url }}').then(response => {
-        if (!response.ok) {
-          console.error('Failed fetching sprite', response);
-          return;_
-        }
-        response.text().then(function(text) {
-          var sprite = document.getElementById('sprite')
-          if (sprite) {
-            sprite.innerHTML = text;
-          } else {
-            window.spriteHTML = text;
-          }
-        });
-      })
-    </script>
     <link rel=stylesheet href="{{ contents.css["main.css"].url }}">
     <link rel=preload href="{{ contents.images["pattern.svg"].url }}" as=image>
-    <link rel=preload href="{{ contents.svg["sprite.svg"].url }}" as=fetch>
     <link rel=preload href="https://use.typekit.net/af/6c9c65/00000000000000003b9adf44/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3"
         as=font crossorigin>
     <link rel=preload href="https://use.typekit.net/af/16a56f/00000000000000003b9adf46/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3"
@@ -54,13 +37,6 @@
     {% endblock %}
   </head>
   <body class="{% block bodyclass %}{% endblock %}">
-    <div id=sprite style="display:none">
-      <script>
-       if (window.spriteHTML) {
-         document.getElementById('sprite').innerHTML = window.spriteHTML;
-       }
-      </script>
-    </div>
     <div class="layout-wrapper">
 
       {% block topbar %}

--- a/templates/pages/index.html.njk
+++ b/templates/pages/index.html.njk
@@ -7,7 +7,7 @@
 {% block content %}
   <section class="tc grid mb6 mb7-l">
     <div class="grid-item-center">
-      {{ svgIcon('jsconf-logo-full', viewBox='0 0 564 84') }}
+      {{ svgIcon(contents, 'jsconf-logo-full', width = 564, height = 84, alt = 'JSConf EU') }}
     </div>
     <p class="grid-item-center">
       June 2nd & 3rd 2018 &mdash; Berlin, Germany
@@ -44,7 +44,7 @@
          last %}
   <section class="tc tl-l grid grid-4-5 mb6 mb7-l">
     <div class="grid-form-home-coc">
-      {{ svgIcon('form-home-coc', viewBox='0 0 658 725', svgClass="svg-scale") }}
+      {{ svgIcon(contents, 'form-home-coc', width = 658, height = 725, svgClass="svg-scale") }}
     </div>
     <h2 class="heading--massive grid-head mt0">
       News

--- a/templates/partials/talk.html.njk
+++ b/templates/partials/talk.html.njk
@@ -16,7 +16,7 @@
       {% if speaker.links.twitter %}
         <li class="speaker-link speaker-link--twitter">
           <a href="{{ speaker.links.twitter }}">
-            {{ svgIcon('icon-twitter-dark')}}
+            {{ svgIcon(contents, 'icon-twitter-dark')}}
             <span>{{ speaker.twitterHandle }}</span>
           </a>
         </li>
@@ -25,7 +25,7 @@
       {% if speaker.links.github %}
         <li class="speaker-link speaker-link--github">
           <a href="{{ speaker.links.github }}">
-            {{ svgIcon('icon-github')}}
+            {{ svgIcon(contents, 'icon-github')}}
             <span>{{ speaker.githubHandle }}</span>
           </a>
         </li>
@@ -34,7 +34,7 @@
       {% if speaker.links.homepage %}
         <li class="speaker-link speaker-link--website">
           <a href="{{ speaker.links.homepage }}">
-            {{ svgIcon('icon-website') }}
+            {{ svgIcon(contents, 'icon-website') }}
             <span>{{ speaker.links.homepage | replace( r/^https?:\/\//, '') }}</span>
           </a>
         </li>

--- a/templates/partials/topbar.html.njk
+++ b/templates/partials/topbar.html.njk
@@ -2,7 +2,7 @@
 
 <div class="topbar bg--evalblack">
   <a href="{{ env.config.baseUrl }}" class="topbar-logo flex-auto flex items-center" title="Home">
-    {{ svgIcon('jsconf-heart', svgClass='w2 h2') }}
+    {{ svgIcon(contents, 'jsconf-heart', svgClass='w2 h2') }}
     <span class="nowrap ml3">
       <span class="topbar-logo-text">JSConf EU</span>
       <span class="topbar-logo-date">June 2nd & 3rd 2018</span>
@@ -17,10 +17,10 @@
       <a href="{{ contents['about.json'].url }}" class="link--promiselinen link--nav">About</a>
       <div class="social-links flex items-center">
         <a href="https://www.youtube.com/jsconfeu" class="link--promiselinen link--nav-icon" title="YouTube">
-          {{ svgIcon('icon-yt')}}
+          {{ svgIcon(contents, 'icon-yt')}}
         </a>
         <a href="https://twitter.com/jsconfeu" class="link--promiselinen link--nav-icon" title="Twitter">
-          {{ svgIcon('icon-twitter')}}
+          {{ svgIcon(contents, 'icon-twitter')}}
         </a>
       </div>
     </nav>


### PR DESCRIPTION
This is a better strategy because

- (and this could be fixed differently) we put way too much crap into the sprite
- sprites are the wrong way under H2

I'm still using an inline SVG with `<image>` element (and a preload element for preload scanner support), so that layout remains unchanged.