### PR TITLE
Switch to CSS based typekit loading.

### DIFF
--- a/contents/sw.js
+++ b/contents/sw.js
@@ -5,7 +5,7 @@ importScripts('https://storage.googleapis.com/workbox-cdn/releases/3.0.0-beta.0/
 
 workbox.routing.registerRoute(
   // Cache typekit bootstrap and font files
-  /^https:\/\/use.typekit\.net\/.+$/,
+  /^https:\/\/(use|p)\.typekit\.net\/.+$/,
   workbox.strategies.staleWhileRevalidate({
     // Use a custom cache name
     cacheName: 'typekit-cache',

--- a/templates/layouts/default.html.njk
+++ b/templates/layouts/default.html.njk
@@ -6,13 +6,13 @@
     <title>{% if page.title %}{{ page.title }}{% endif %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel=stylesheet href="{{ contents.css["main.css"].url }}">
+    <link rel=stylesheet href="https://use.typekit.net/gug4wmv.css">
     <link rel=preload href="{{ contents.images["pattern.svg"].url }}" as=image>
     <link rel=preload href="https://use.typekit.net/af/6c9c65/00000000000000003b9adf44/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3"
         as=font crossorigin>
-    <link rel=preload href="https://use.typekit.net/af/16a56f/00000000000000003b9adf46/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3"
+    <link rel=preload href="https://use.typekit.net/af/d4bd37/00000000000000003b9adf46/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3"
         as=font crossorigin>
     <script src="{{ contents.js['main.js'].url }}" defer></script>
-    <script src="https://use.typekit.net/gug4wmv.js" async onload="try{Typekit.load({ async: true });}catch(e){}"></script>
 
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">


### PR DESCRIPTION
Will get rid of the FOUT.
And updates preloads to current state (switches every 100 days).