### PR TITLE
Fix long speaker names break layout on small devices

### DIFF
--- a/contents/css/_speaker.css
+++ b/contents/css/_speaker.css
@@ -91,6 +91,7 @@
 .speaker-detail h1 {
   text-align: center;
   margin-bottom: 1rem;
+  word-break: break-word;
 }
 .speaker-detail h2 {
   padding-bottom: 0.35rem;


### PR DESCRIPTION
Sorry, my long last name is breaking the layout.
`word-break: break-word;` should fix this without affecting other pages.

![iphone5se](https://user-images.githubusercontent.com/1016218/38127977-16af9c4a-342b-11e8-93b5-d0406d84bf17.jpg)
