### PR TITLE
Fix CSS specificity conflict.

### DIFF
--- a/contents/css/_links.css
+++ b/contents/css/_links.css
@@ -11,7 +11,7 @@ a {
 
 /* Default links on main content area */
 .md-content a:not(.link--nounderline),
-.speaker-detail p a:not(.link--nounderline),
+.speaker-detail .talk-description a:not(.link--nounderline),
 .link--underline {
   border-bottom: 4px solid var(--returnrose);
 

--- a/templates/partials/talk.html.njk
+++ b/templates/partials/talk.html.njk
@@ -10,7 +10,9 @@
       <h2 class="heading--no-border">{{ speaker.talkTitle }}</h2>
     </header>
 
-    {{ page.html }}
+    <section class="talk-description">
+      {{ page.html }}
+    </section>
 
     <ul class="speaker-links">
       {% if speaker.links.twitter %}


### PR DESCRIPTION
This limits the default-underlining of links to the actual body of the speaker page and avoids a specificity conflict with the buy button.

Fixes #176