### PR TITLE
Stop preloading the background.

### DIFF
--- a/templates/layouts/default.html.njk
+++ b/templates/layouts/default.html.njk
@@ -75,6 +75,5 @@
 
     </div>
   <script src="{{ contents.js['main.js'].url }}" async></script>
-  <link rel=preload href="{{ contents.images["pattern.svg"].url }}" as=image>
   </body>
 </html>


### PR DESCRIPTION
It steals bandwidth from high priority resources and leads early rasterization may delay paint.

See https://bugs.chromium.org/p/chromium/issues/detail?id=838396