### PR TITLE
schedule now shows parallel events next to each other

### DIFF
--- a/schedule.json
+++ b/schedule.json
@@ -383,9 +383,7 @@
           "who": "Tracy Hinds",
           "what": "Merge Conflict: a case study and application of peer conflict management training in Node.js",
           "dateTime": "2018-06-02 17:45 GMT+0200"
-        }
-      ],
-      "17:45": [
+        },
         {
           "day": 1,
           "date": "2018-06-02",

--- a/templates/pages/schedule.html.njk
+++ b/templates/pages/schedule.html.njk
@@ -310,6 +310,19 @@ article.with-description {
 .notice a{
   color: inherit;
 }
+
+@media (min-width: 767px) {
+  .time-row{
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+
+  .time-row-item{
+    flex: 1 0 0;
+  }
+}
+
 </style>
 
 </head>
@@ -335,6 +348,7 @@ article.with-description {
     <h2>Day {{ day }}</h2>
     <ul class="events">
       {% for session, talks in sessions %}
+        <div class="time-row">
         <li class="time" id="day{{ day }}-{{ session | replace('.', '-') }}">
           <h3>{{ session }}</h3>
         </li>
@@ -352,7 +366,7 @@ article.with-description {
           {% endfor %}
           <li
               datetime="{{ talk.dateTime }}"
-              class="session {{ talk.trackId }}"
+              class="session {{ talk.trackId }} time-row-item"
               {% if talkPage %}
                 id="talk-{{ talkPage.metadata.speaker.id }}"
               {% else %}
@@ -388,6 +402,7 @@ article.with-description {
             </article>
           </li>
         {% endfor %}
+        </div>
       {% endfor %}
     </ul>
     </div>


### PR DESCRIPTION
BEFORE MERGING TO PRODUCTION: check if everything works when event details are shown - for some reason I am unable to access the `onclick - show further event details` functionality, so I can't manually test that it works.

- this works on screens wider than 767 px (smaller have the single column view)
- works on Chrome & Firefox (unable to manually check other browsers)
- also changed the schedule.json (previously day 1 array , had two "17:45" keys, each with array of one - now there's only one "17:45" key and its array has two items)
