### PR TITLE
Cleaned up print view

### DIFF
--- a/schedule.json
+++ b/schedule.json
@@ -383,9 +383,7 @@
           "who": "Tracy Hinds",
           "what": "Merge Conflict: a case study and application of peer conflict management training in Node.js",
           "dateTime": "2018-06-02 17:45 GMT+0200"
-        }
-      ],
-      "17:45": [
+        },
         {
           "day": 1,
           "date": "2018-06-02",

--- a/schedule.json
+++ b/schedule.json
@@ -383,8 +383,10 @@
           "who": "Tracy Hinds",
           "what": "Merge Conflict: a case study and application of peer conflict management training in Node.js",
           "dateTime": "2018-06-02 17:45 GMT+0200"
-        },
-        {
+        }
+      ],
+     "17:45": [
+		 {
           "day": 1,
           "date": "2018-06-02",
           "track": "Side Track",

--- a/templates/pages/schedule.html.njk
+++ b/templates/pages/schedule.html.njk
@@ -323,6 +323,72 @@ article.with-description {
   }
 }
 
+
+@media print {
+
+
+
+  header {
+    display: none;
+  }
+
+  li {
+    page-break-inside: avoid;
+  }
+
+  .notice{
+    display: none;
+  }
+
+  nav{
+    display: none;
+  }
+
+  .time-row{
+    display: flex;
+    flex-wrap: wrap;;
+    justify-content: flex-start;
+    page-break-inside: avoid;
+    border-bottom: 1px solid;
+  }
+
+  .time-row-item{
+    flex: 1 0 0;
+  }
+
+  .day{
+    padding-top: 2rem;
+    padding-bottom: 1rem;
+  }
+
+  body{
+    color: black;
+    background-color: white;
+  }
+
+  .day h2{
+    color: black;
+  }
+
+  .day .session h3{
+    color: black;
+  }
+
+  .day .session h3 .speaker{
+    color: #A9A9A9;
+  }
+
+  .day .session .track{
+    color: #A9A9A9;
+  }
+
+  .day .session time {
+    color: black;
+  }
+
+}
+
+
 </style>
 
 </head>

--- a/templates/pages/schedule.html.njk
+++ b/templates/pages/schedule.html.njk
@@ -310,6 +310,19 @@ article.with-description {
 .notice a{
   color: inherit;
 }
+
+@media (min-width: 767px) {
+  .time-row{
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+
+  .time-row-item{
+    flex: 1 0 0;
+  }
+}
+
 </style>
 
 </head>
@@ -335,6 +348,7 @@ article.with-description {
     <h2>Day {{ day }}</h2>
     <ul class="events">
       {% for session, talks in sessions %}
+        <div class="time-row">
         <li class="time" id="day{{ day }}-{{ session | replace('.', '-') }}">
           <h3>{{ session }}</h3>
         </li>
@@ -352,7 +366,7 @@ article.with-description {
           {% endfor %}
           <li
               datetime="{{ talk.dateTime }}"
-              class="session {{ talk.trackId }}"
+              class="session {{ talk.trackId }} time-row-item"
               {% if talkPage %}
                 id="talk-{{ talkPage.metadata.speaker.id }}"
               {% else %}
@@ -388,6 +402,7 @@ article.with-description {
             </article>
           </li>
         {% endfor %}
+        </div>
       {% endfor %}
     </ul>
     </div>


### PR DESCRIPTION
I don't know why the schedule.json shows as updated, not sure how to exclude it from the PR. 

Gray speaker names and track names are deliberate to avoid block of black. 

**Screenshot
![print-preview](https://user-images.githubusercontent.com/31079643/40723111-ffd7a59c-6415-11e8-9076-13a1a5a2ab35.png)
** 